### PR TITLE
fix: pagenation이 버튼을 의도보다 많이 출력하는 현상 수정 외 1

### DIFF
--- a/batch/scraping/bandai/daily-scraping.py
+++ b/batch/scraping/bandai/daily-scraping.py
@@ -375,52 +375,53 @@ def scraping_detail_info(product_list_json, start_idx=0, mode=0):
 #     f.close()
 
 
-# 오늘 날짜를 YYYYMMDD 형식으로 출력
-today = datetime.today().strftime("%Y%m%d")
-print(today)
-# 데일리 스크래핑 순서
+if __name__ == "__main__":
+    # 오늘 날짜를 YYYYMMDD 형식으로 출력
+    today = datetime.today().strftime("%Y%m%d")
+    print(today)
+    # 데일리 스크래핑 순서
 
-# 1. bandai_capsule_toy_list() 실행
-# 이번달부터 1년치의 상품 리스트를 가져온다.
-# 출력 파일은 'daily-scraping-YYYYMMDD.json'
-print("bandai_capsule_toy_list")
-bandai_capsule_toy_list()
+    # 1. bandai_capsule_toy_list() 실행
+    # 이번달부터 1년치의 상품 리스트를 가져온다.
+    # 출력 파일은 'daily-scraping-YYYYMMDD.json'
+    print("bandai_capsule_toy_list")
+    bandai_capsule_toy_list()
 
+    # 2. search_new_product() 실행
+    # 입력 파일은 'daily-scraping-YYYYMMDD.json'
+    # DB에 저장된 상품 리스트와 비교
+    # DB에 저장된 상품이면 기존 dict에 'date_added'를 추가
+    # DB에 저장되지 않은 상품이면 별다른 편집 없음
+    # 출력 파일은 'new-product-YYYYMMDD.json'
+    print("search_new_product")
+    write_file(
+        search_new_product(absolute_path_bandai + "daily-scraping/" + today + ".json"),
+        absolute_path_bandai + "new-product/",
+    )
 
-# 2. search_new_product() 실행
-# 입력 파일은 'daily-scraping-YYYYMMDD.json'
-# DB에 저장된 상품 리스트와 비교
-# DB에 저장된 상품이면 기존 dict에 'date_added'를 추가
-# DB에 저장되지 않은 상품이면 별다른 편집 없음
-# 출력 파일은 'new-product-YYYYMMDD.json'
-print("search_new_product")
-write_file(
-    search_new_product(absolute_path_bandai + "daily-scraping/" + today + ".json"),
-    absolute_path_bandai + "new-product/",
-)
+    # 3. scraping_detail_info() 실행
+    # 입력 파일은 'new-product-YYYYMMDD.json'
+    # 입력 파일의 각 'detail_url'에 접속하여 상품 정보를 가져온다.
+    # 출력 파일은 'image-updated-YYYYMMDD.json'
+    print("scraping_detail_info")
+    scraping_detail_info(
+        absolute_path_bandai + "new-product/" + today + ".json", mode=0
+    )
 
-# 3. scraping_detail_info() 실행
-# 입력 파일은 'new-product-YYYYMMDD.json'
-# 입력 파일의 각 'detail_url'에 접속하여 상품 정보를 가져온다.
-# 출력 파일은 'image-updated-YYYYMMDD.json'
-print("scraping_detail_info")
-scraping_detail_info(absolute_path_bandai + "new-product/" + today + ".json", mode=0)
+    # 4. insert_new_product() 실행
+    print("insert_new_product")
+    insert_new_product(absolute_path_bandai + "new-product/detail-" + today + ".json")
 
-# 4. insert_new_product() 실행
-print("insert_new_product")
-insert_new_product(absolute_path_bandai + "new-product/detail-" + today + ".json")
+    # DB에 저장된 상품의 이미지를 업데이트하는 순서
 
+    # 이미지가 없는 상품을 DB에서 찾아 그 결과를 출력하는 함수
+    print("search_blank_image")
+    write_file(search_blank_image("BANDAI"), absolute_path_bandai + "blank-img/")
 
-# DB에 저장된 상품의 이미지를 업데이트하는 순서
+    # 이미지가 없는 상품의 상세 페이지에서 이미지를 가져오는 함수
+    print("scraping_detail_info")
+    scraping_detail_info(absolute_path_bandai + "blank-img/" + today + ".json", mode=1)
 
-# 이미지가 없는 상품을 DB에서 찾아 그 결과를 출력하는 함수
-print("search_blank_image")
-write_file(search_blank_image("BANDAI"), absolute_path_bandai + "blank-img/")
-
-# 이미지가 없는 상품의 상세 페이지에서 이미지를 가져오는 함수
-print("scraping_detail_info")
-scraping_detail_info(absolute_path_bandai + "blank-img/" + today + ".json", mode=1)
-
-# 가져온 이미지 정보를 DB에 업데이트하는 함수
-print("insert_updated_image")
-insert_updated_image(absolute_path_bandai + "blank-img/updated-" + today + ".json")
+    # 가져온 이미지 정보를 DB에 업데이트하는 함수
+    print("insert_updated_image")
+    insert_updated_image(absolute_path_bandai + "blank-img/updated-" + today + ".json")

--- a/next-app/src/app/[lng]/capsule/[id]/page.tsx
+++ b/next-app/src/app/[lng]/capsule/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { ICapsuleToy } from "@/lib/models/capsule-model";
 import Image from "next/image";
 import ImageGallery from "../../components/image-gallery";
+import Link from "next/link";
 
 const IMAGE_URI = process.env.IMAGE_SERVER_URL || "";
 const API_URI = process.env.APP_SERVER_URL || "";
@@ -39,7 +40,12 @@ export default async function Page({ params }: { params: { id: string } }) {
       </div>
       <div className="p-5">
         <h1 className="text-heading2-bold pb-5">{capsule.name}</h1>
-        <p className="text-body-medium">{capsule.description}</p>
+        <p className="text-body-medium pb-5">{capsule.description}</p>
+        <p className="text-body-medium pb-5">
+          <Link href={capsule.detail_url} as={capsule.detail_url}>
+            Site Link
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/next-app/src/app/[lng]/components/pagination.tsx
+++ b/next-app/src/app/[lng]/components/pagination.tsx
@@ -3,6 +3,7 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { perPageEnum } from "@/lib/per-page-enum";
 
 interface PaginationProps {
   total: number; // total number of items
@@ -14,7 +15,7 @@ export default function Pagination({ total }: PaginationProps) {
   const searchParams = useSearchParams();
 
   const currentPage = Number(searchParams.get("page")) || 1;
-  const itemsPerPage = Number(searchParams.get("limit")) || 15;
+  const itemsPerPage = Number(searchParams.get("limit")) || perPageEnum.SMALL;
   const totalPages = Math.ceil(total / itemsPerPage);
 
   const maxPagesToShow = 10;

--- a/next-app/src/lib/per-page-enum.ts
+++ b/next-app/src/lib/per-page-enum.ts
@@ -1,0 +1,5 @@
+export enum perPageEnum {
+  SMALL = 20,
+  MEDIUM = 40,
+  LARGE = 60,
+}

--- a/next-app/src/lib/search-params.ts
+++ b/next-app/src/lib/search-params.ts
@@ -1,10 +1,5 @@
 import { dateConveter } from "@/lib/date-converter";
-
-enum perPageEnum {
-  SMALL = 20,
-  MEDIUM = 40,
-  LARGE = 60,
-}
+import { perPageEnum } from "@/lib/per-page-enum";
 
 export function searchParams(url: string) {
   const params = new URLSearchParams(new URL(url).search);


### PR DESCRIPTION
[Update daily-scraping.py](https://github.com/ucharles/gachatory/commit/cd68f2b702df9eb491c3446d8ad469dce1df6323) 

- main 구문 추가

[fix: pagenation이 버튼을 의도보다 많이 출력하는 현상 수정](https://github.com/ucharles/gachatory/commit/f1ace22f31de8c1428792b24cbb25f653f1e246a) 

- Pagenation 컴포넌트의 페이지 당 상품 개수 디폴트 값을 15->20로 수정
- 테스트의 잔재가 남아 있었음
- 페이지 당 상품 개수를 필요로 하는 곳에 enum 추가
- enum을 기존 코드와 분리시킴