### PR TITLE
`/search?tag=(id)` 관련 수정

### DIFF
--- a/next-app/src/app/[lng]/components/display-capsule-tag.tsx
+++ b/next-app/src/app/[lng]/components/display-capsule-tag.tsx
@@ -46,7 +46,7 @@ function DisplayCapsuleTags({
   return (
     <React.Fragment>
       {tags.map((tag, index) => (
-        <Link href={`/${lng}/search?name=${tag["ja"][0]}`} key={index}>
+        <Link href={`/${lng}/search?tag=${tag._id}`} key={index}>
           <span
             key={index}
             className="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2"

--- a/next-app/src/app/api/tags/route.ts
+++ b/next-app/src/app/api/tags/route.ts
@@ -49,7 +49,7 @@ export async function GET(request: Request) {
     } else if (objectIdTagIds) {
       resultCapsuleTags = await CapsuleTag.find({
         _id: { $in: objectIdTagIds },
-      }).sort({ linkCount: -1 });
+      });
     } else if (searchString) {
       resultCapsuleTags = await CapsuleTag.find({
         $or: [{ ja: searchString }, { en: searchString }, { ko: searchString }],


### PR DESCRIPTION
- `/search`에서 `tag`에 입력된 `id`의 순서대로 태그가 표시되도록 수정
- #36