### PR TITLE
/[lng]/search 빌드 오류 해결

### DIFF
--- a/next-app/src/app/[lng]/search/page.tsx
+++ b/next-app/src/app/[lng]/search/page.tsx
@@ -98,7 +98,7 @@ export default async function Page({
               <div className="pb-3">
                 <h1 className="space-x-2 text-heading3-bold">
                   <span className="text-gigas-700">
-                    '{keyword ? `${keyword}` : tagId ? `#${tagId}` : ""}'
+                    {keyword ? `'${keyword}'` : tagId ? `'#${tagId}'` : "''"}
                   </span>
                   <span>{t("result")}</span>
                 </h1>


### PR DESCRIPTION
따옴표를 외부가 아닌 내부로 이동