### PR TITLE
`/api/capsules`에 한국어 혹은 영어 검색시 sort 옵션 제외

### DIFF
--- a/next-app/src/app/api/capsules/route.ts
+++ b/next-app/src/app/api/capsules/route.ts
@@ -79,7 +79,6 @@ export async function GET(request: Request) {
       })
         .skip((currentPage - 1) * perPage)
         .limit(perPage)
-        .sort(sortQuery)
         .populate([
           {
             path: "capsuleId",


### PR DESCRIPTION
- sortQuery에는 dateISO 필드가 있는데, 이는 Localication에는 존재하지 않음
- 이 때문에 데이터가 제대로 출력되지 않는 버그 발생